### PR TITLE
Fix variable names in create-docker-machine playbook

### DIFF
--- a/ansible/create-docker-machine.yml
+++ b/ansible/create-docker-machine.yml
@@ -21,9 +21,9 @@
       become: false
       local_action:
         shell docker-machine create -d generic
-          --generic-ssh-user {{ ansible_ssh_user }}
-          --generic-ssh-key  {{ ansible_ssh_private_key_file }}
-          --generic-ip-address {{ hostvars[inventory_hostname]['ansible_ssh_host'] }}
+          --generic-ssh-user {{ ansible_user }}
+          --generic-ssh-key  {{ ansible_private_key_file }}
+          --generic-ip-address {{ hostvars[inventory_hostname]['ansible_host'] }}
           {{ docker_machine_options }}
             {{ inventory_hostname }}
       when: dm_present|failed
@@ -32,9 +32,9 @@
       debug:
         msg: |
           docker-machine create -d generic
-            --generic-ssh-user {{ ansible_ssh_user }}
-            --generic-ssh-key  {{ ansible_ssh_private_key_file }}
-            --generic-ip-address {{ hostvars[inventory_hostname]['ansible_ssh_host'] }}
+            --generic-ssh-user {{ ansible_user }}
+            --generic-ssh-key  {{ ansible_private_key_file }}
+            --generic-ip-address {{ hostvars[inventory_hostname]['ansible_host'] }}
             {{ docker_machine_options }}
               {{ inventory_hostname }}
       tags: debug


### PR DESCRIPTION
This should fix a bug on variable names introduced with
commit #7bdffb7