### PR TITLE
Source additional files from dopsinit dir

### DIFF
--- a/rc/.myzshrc
+++ b/rc/.myzshrc
@@ -168,3 +168,7 @@ randword() {
   local qualifier=$(shuf -n 1 /usr/share/dict/qualifiers)
   echo "$name-$qualifier"
 }
+
+# Source additional user files that may exist in ~/.dopsinit
+[[ -d ~/.dopsinit ]] && \
+  for f in ~/.dopsinit/*; do source $f; done


### PR DESCRIPTION
When inheriting from the base dops image, we may want to add additional files to be sourced in dops zsh. This PR does source every file added in `/root/.dopsinit/`.