### PR TITLE
Stay compatible with openssl >1.1

### DIFF
--- a/bin/vault
+++ b/bin/vault
@@ -16,7 +16,7 @@ encrypt_file() {
     local decryptedFile=$1
     local encryptedFile=$decryptedFile.encrypt
 
-    cat $decryptedFile | openssl aes-256-cbc -salt -a -k $PASSWORD | comment > $encryptedFile
+    cat $decryptedFile | openssl aes-256-cbc -salt -a -k $PASSWORD -md md5 | comment > $encryptedFile
     [[ ${USERID:-} != "" ]] && chown $USERID:$USERID $encryptedFile || true
 }
 
@@ -24,7 +24,7 @@ decrypt_file() {
     local encryptedFile=$1
     local decryptedFile=$2
 
-    cat $encryptedFile | uncomment | openssl aes-256-cbc -d -a -k $PASSWORD > $decryptedFile
+    cat $encryptedFile | uncomment | openssl aes-256-cbc -d -a -k $PASSWORD -md md5 > $decryptedFile
     [[ ${USERID:-} != "" ]] && chown $USERID:$USERID $decryptedFile || true
 }
 


### PR DESCRIPTION
OpenSSL v1.1 switched the default md from md5 to sha1.
Running this script may then lead to different results depending from the system openssl version.

There is no problem with dops, based on a fixed alpine version with a fixed openssl version. However some people (like me) like to reuse your `vault` script only on a different platform.

This fix makes the script compatible with both OpenSSL <1.1 and OpenSSL >=1.1.
I tested it with a machine with OpenSSL 0.9.8zh and a machine with OpenSSL 1.1.0f.